### PR TITLE
set cors settings to allow all origins

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.openapi.docs import get_swagger_ui_html
 from core.util.constants import (
@@ -34,6 +35,15 @@ api = FastAPI(
         NAME: API_LICENSE_NAME,
         URL: GITHUB_LICENSE_URL,
     }
+)
+
+origins = ["*"]
+
+api.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["GET"],
 )
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -37,15 +37,13 @@ api = FastAPI(
     }
 )
 
-origins = ["*"]
-
+# Add middleware
 api.add_middleware(
     CORSMiddleware,
-    allow_origins=origins,
+    allow_origins=["*"],
     allow_credentials=True,
     allow_methods=["GET"],
 )
-
 
 # Add Routers
 api.include_router(v1_router)


### PR DESCRIPTION
this may requires to install another package regarding the import

## Summary

I've tried creating a little frontend app through StackBlitz but was unable to fetch data from the api without a CORS proxy service. I generally like to avoid using CORS proxies and this change should help.

## Type of Change

Please select all that apply:

- [x] New Feature
- [ ] Bug Fix
- [ ] Schema Update
- [ ] Documentation Update
